### PR TITLE
fix: clearing runtime defaults slightly later

### DIFF
--- a/Runtime/EcsactRuntime.cs
+++ b/Runtime/EcsactRuntime.cs
@@ -741,7 +741,7 @@ public class EcsactRuntime {
 	static EcsactRuntime() {
 #if UNITY_EDITOR
 		EditorApplication.playModeStateChanged += state => {
-			if(state == PlayModeStateChange.ExitingPlayMode) {
+			if(state == PlayModeStateChange.EnteredEditMode) {
 				Ecsact.Internal.EcsactRuntimeDefaults.ClearDefaults();
 			}
 		};


### PR DESCRIPTION
Often there are accesses to the default runtime in OnDestroy and similar which would cause an exception to occur on quit during editor play.
